### PR TITLE
Enable "Edit on GitHub" for example extension manual

### DIFF
--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -39,8 +39,8 @@ copyright   = by {extension.extensionKey}
 # ...  (recommended) to get the "Edit me on Github Button"
 # .................................................................................
 
-#github_branch        = master
-#github_repository    = TYPO3-Documentation/TYPO3CMS-Example-ExtensionManual
+github_branch        = master
+github_repository    = TYPO3-Documentation/TYPO3CMS-Example-ExtensionManual
 
 
 # .................................................................................


### PR DESCRIPTION
Previously, the [rendered version](https://docs.typo3.org/m/typo3/guide-example-extension-manual/master/en-us/) does not show "Edit on GitHub". Adding this might make it easier to contribute and make minor changes.