### PR TITLE
Remove section for contributors

### DIFF
--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -49,11 +49,6 @@ If you find an error or something is missing, please:
 
 This documentation is for the TYPO3 extension <extkey>.
 
-**For Contributors**
-
-You are welcome to help improve this guide.
-Just click on "Edit me on GitHub" on the top right to submit your change request.
-
 ..   Note for editors:
 ..   temporarily removed from menu:
 ..   Introduction/Index


### PR DESCRIPTION
- may become outdated and than will still exist in extensions for years
- is better handled by theme and is now handled well with "Edit on GitHub"
  button and "i - How to edit" button
- In any case, we should avoid language like "Just ... do something" as it
  applies this is an easy task when in fact it may not (see Symfony styleguide)