### PR TITLE
Replace links to start page (:doc: => :ref:)

### DIFF
--- a/Documentation/Installation/Index.rst
+++ b/Documentation/Installation/Index.rst
@@ -10,4 +10,4 @@ Installation
 *   Are there any dependencies that need to be resolved?
 
 References to general TYPO3 documentation are possible,
-for example the :doc:`t3install:Index`.
+for example the :ref:`t3install:start`.

--- a/Documentation/Templates/Override.rst
+++ b/Documentation/Templates/Override.rst
@@ -11,7 +11,7 @@ This documentation won't bring you all information about Fluid but only the
 most important things you need for using it. You can get
 more information in the section :ref:`Fluid templates of the Sitepackage tutorial
 <t3sitepackage:fluid-templates>`. A complete reference of Fluid ViewHelpers
-provided by TYPO3 can be found in the  :doc:`ViewHelper Reference <t3viewhelper:Index>`
+provided by TYPO3 can be found in the  :ref:`ViewHelper Reference <t3viewhelper:start>`
 
 
 ..  index:: Templates; TypoScript
@@ -26,7 +26,7 @@ If you want to change a template, copy the desired files to the directory
 where you store the templates.
 
 We suggest that you use a sitepackage extension. Learn how to
-:doc:`Create a sitepackage extension <t3sitepackage:Index>`.
+:ref:`Create a sitepackage extension <t3sitepackage:start>`.
 
 ..  code-block:: typoscript
 


### PR DESCRIPTION
We now use the start label again to link to start pages

Related: TYPO3-Documentation/T3DocTeam#198