### PR TITLE
[TASK] Remove outdated manuals from list in Settings.cfg

### DIFF
--- a/Documentation/Installation/Index.rst
+++ b/Documentation/Installation/Index.rst
@@ -10,4 +10,4 @@ Installation
 *   Are there any dependencies that need to be resolved?
 
 References to general TYPO3 documentation are possible,
-for example the :ref:`t3install:start`.
+for example the :ref:`t3upgrade:start`.

--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -30,11 +30,9 @@ h2document     = https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/
 # t3content      = https://docs.typo3.org/m/typo3/guide-contentandmarketing/main/en-us/
 # t3contribute   = https://docs.typo3.org/m/typo3/guide-contributionworkflow/main/en-us/
 t3coreapi      = https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/
-# t3docteam      = https://docs.typo3.org/m/typo3/team-t3docteam/main/en-us/
 # t3editors      = https://docs.typo3.org/m/typo3/tutorial-editors/main/en-us/
 # t3extexample   = https://docs.typo3.org/m/typo3/guide-example-extension-manual/main/en-us/
 # t3home         = https://docs.typo3.org/
-t3install      = https://docs.typo3.org/m/typo3/guide-installation/main/en-us/
 t3sitepackage  = https://docs.typo3.org/m/typo3/tutorial-sitepackage/main/en-us/
 # t3start        = https://docs.typo3.org/m/typo3/tutorial-getting-started/main/en-us/
 # t3tca          = https://docs.typo3.org/m/typo3/reference-tca/main/en-us/
@@ -43,7 +41,7 @@ t3sitepackage  = https://docs.typo3.org/m/typo3/tutorial-sitepackage/main/en-us/
 # t3tsref        = https://docs.typo3.org/m/typo3/reference-typoscript/main/en-us/
 # t3ts45         = https://docs.typo3.org/m/typo3/tutorial-typoscript-in-45-minutes/main/en-us/
 t3viewhelper   = https://docs.typo3.org/other/typo3/view-helper-reference/main/en-us/
-# t3upgrade      = https://docs.typo3.org/m/typo3/guide-installation/main/en-us/
+t3upgrade      = https://docs.typo3.org/m/typo3/guide-installation/main/en-us/
 
 # TYPO3 system extensions
 # ext_adminpanel     = https://docs.typo3.org/c/typo3/cms-adminpanel/main/en-us/


### PR DESCRIPTION
- "t3docteam" is outdated and not maintained anymore.
- "t3install" is superseded by "t3upgrade" as this was renamed from "Installation Guide" to "Upgrade Guide"