### PR TITLE
remove unused use-opensearch

### DIFF
--- a/Documentation/guides.xml
+++ b/Documentation/guides.xml
@@ -10,7 +10,6 @@
              project-repository="&lt;project-repository&gt;"
              project-issues="&lt;project-issues&gt;"
              project-discussions="&lt;project-discussions&gt;"
-             use-opensearch="&lt;use-opensearch&gt;"
              edit-on-github-branch="main"
              edit-on-github="TYPO3-Documentation/TYPO3CMS-Example-ExtensionManual"
              typo3-core-preferred="stable"


### PR DESCRIPTION
According to Garvin Hicking the option is not used any more.

See https://typo3.slack.com/archives/C028JEPJL/p1721382150176549?thread_ts=1721337553.388079&cid=C028JEPJL